### PR TITLE
Fix error where energy_collector.lua tries to compare to nil

### DIFF
--- a/energy_collector.lua
+++ b/energy_collector.lua
@@ -95,7 +95,9 @@ local function on_timer(pos, elapsed)
         using_orb = false
     end
 
-    if minetest.get_natural_light(above) >= 14 then
+    local light = minetest.get_natural_light(above)
+
+    if light and light >= 14 then
         if check_for_furnaces(pos, 1, true) then
             -- do nothing, energy is being used for the furnace.
             return true


### PR DESCRIPTION
Fixes the following error:
```
2023-11-20 23:40:18: ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod 'exchangeclone' in callback node_on_timer(): ...netest/.minetest/mods/exchangeclone/energy_collector.lua:98: attempt to compare number with nil
2023-11-20 23:40:18: ERROR[Main]: stack traceback:
2023-11-20 23:40:18: ERROR[Main]: 	...netest/.minetest/mods/exchangeclone/energy_collector.lua:98: in function <...netest/.minetest/mods/exchangeclone/energy_collector.lua:85>
```